### PR TITLE
NCIATWP-8454: Section 508 fixes (Login, Home, Search Samples)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# NCI Standard Public Repository Security Policy
+
+## Maintained Versions
+
+Actively maintained versions of contained software will vary from repository to repository, or may not be relevant at all.  
+The developers of this repository will update this section if any actively maintained versions of the software need to be publicly disclosed. Otherwise, contact the developers directly for any version information.
+
+## Vulnerability Disclosure:
+
+### Option 1: HHS Vulnerability Disclosure
+
+Follow the instructions listed in the [HHS vulnerability disclosure policy](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
+
+### Option 2: Private Vulnerability Report
+
+1. Click on the **Security and quality** tab of this repository.
+2. Locate the **Report a vulnerability** button. If the button is not on the **Security and quality** landing page, look under the **Advisories** section in the side bar.
+3. Click the **Report a vulnerability** button and submit the form. The developers will receive a notification of your submission.
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -250,6 +250,12 @@ main a:hover {
     margin-top: 75px;
 }
 
+/* Darken muted text on the Search Samples page so it meets WCAG AA 4.5:1
+   contrast (Bootstrap's default .text-muted #6c757d sits at the threshold). */
+.biosample_tab .text-muted {
+    color: #616970 !important;
+}
+
 .hover-grey-button {
     background-color: transparent;
     border-width: 0;

--- a/templates/accounts/account/login.html
+++ b/templates/accounts/account/login.html
@@ -29,7 +29,7 @@
                                         type="submit">{% trans "Sign In" %}</button>
                             </div>
                             <div>
-                                <a class="secondaryAction" href="{% url 'account_reset_password' %}">Forgot your Password?</a>
+                                <a class="secondaryAction text-decoration-underline" href="{% url 'account_reset_password' %}">Forgot your Password?</a>
                             </div>
                         </div>
                     </div>

--- a/templates/ctb/landing.html
+++ b/templates/ctb/landing.html
@@ -57,24 +57,24 @@
                     <div class="row">
                         <div class="col stat-card">
                             <a href="{% url 'about' %}" class="fill-div">
-                                <h5 class="fw-bold aqua-green-text"><i class="fas fa-radiation pb-2"></i><br/>About</h5>
+                                <h2 class="fs-5 fw-bold aqua-green-text"><i class="fas fa-radiation pb-2"></i><br/>About</h2>
                                 <div class="mt-3">An introduction to the CTB project</div>
                             </a>
                         </div>
                         <div class="col stat-card">
                             <a href="{% url 'research' %}" class="fill-div">
-                                <h5 class="fw-bold orange-text"><i class="fas fa-atom pb-2"></i><br>Research and Data
+                                <h2 class="fs-5 fw-bold orange-text"><i class="fas fa-atom pb-2"></i><br>Research and Data
                                     Access
-                                </h5>
+                                </h2>
                                 <div class="mt-3">Information to research into the Chernobyl accident</div>
                             </a>
                         </div>
                         <div class="col stat-card">
                             <a href="{% if user.is_verified %} {% url 'dashboard' %} {% else %} {% url 'two_factor:login' %}" {% endif %}
                                class="fill-div">
-                                <h5 class="fw-bold dark-aqua-text"><i class="fas fa-search pb-2"></i><br/>Search the
+                                <h2 class="fs-5 fw-bold dark-aqua-text"><i class="fas fa-search pb-2"></i><br/>Search the
                                     Biorepository
-                                </h5>
+                                </h2>
                                 <div class="mt-3">Find your biological samples for your study</div>
                             </a>
                         </div>
@@ -109,24 +109,24 @@
             <div class="col-10 mx-auto py-3">
                 <div class="stat-card mb-4">
                     <a href="{% url 'about' %}" class="fill-div">
-                        <h5 class="fw-bold aqua-green-text"><i class="fas fa-radiation pb-2"></i> About</h5>
+                        <h2 class="fs-5 fw-bold aqua-green-text"><i class="fas fa-radiation pb-2"></i> About</h2>
                         <div class="mt-3">An introduction to the CTB project</div>
                     </a>
                 </div>
                 <div class="stat-card mb-4">
                     <a href="{% url 'research' %}" class="fill-div">
-                        <h5 class="fw-bold orange-text"><i class="fas fa-atom pb-2"></i> Research & Data
+                        <h2 class="fs-5 fw-bold orange-text"><i class="fas fa-atom pb-2"></i> Research & Data
                             Access
-                        </h5>
+                        </h2>
                         <div class="mt-3">Information to research into the Chernobyl accident</div>
                     </a>
                 </div>
                 <div class="stat-card mb-4">
                     <a href="{% if user.is_verified %} {% url 'dashboard' %} {% else %} {% url 'two_factor:login' %}" {% endif %}
                        class="fill-div">
-                        <h5 class="fw-bold dark-aqua-text"><i class="fas fa-search pb-2"></i> Search the
+                        <h2 class="fs-5 fw-bold dark-aqua-text"><i class="fas fa-search pb-2"></i> Search the
                             Biorepository
-                        </h5>
+                        </h2>
                         <div class="mt-3">Find your biological samples for your study</div>
                     </a>
                 </div>

--- a/templates/share/site_header.html
+++ b/templates/share/site_header.html
@@ -52,13 +52,12 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link {% if 'search_facility' in request.path %} active {% endif %}"
-                           aria-current="page"
                            href="{% url 'dashboard' %}">
                             Search the Biorepository
                         </a>
                     </li>
                 </ul>
-                <div class="navbar-nav">
+                <ul class="navbar-nav">
                     <li class="nav-item d-none d-xl-inline-block">
                         <a class="nav-link btn me-3 collapsed" type="button" id="SearchBarCollapse2"
                            data-bs-toggle="collapse"
@@ -96,7 +95,7 @@
                             </a>
                         </li>
                     {% endif %}
-                </div>
+                </ul>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
**Jira ticket: [NCIATWP-8454](https://tracker.nci.nih.gov/browse/NCIATWP-8454)**
**Dev UI: [chernobyltissuebank-dev.cancer.gov](https://chernobyltissuebank-dev.cancer.gov)**

## Ticket(s)
- NCIATWP-8454 — Section 508 / WCAG accessibility fixes for the Login, Home, and Search Samples pages (axe-core findings).

## Summary of changes
1. **Links must be distinguishable without relying on color** (Login) — `templates/accounts/account/login.html`: added the `text-decoration-underline` class to the "Forgot your Password?" link so it is distinguishable by an underline, not color alone.
2. **`<li>` elements must be used semantically** (Home) — `templates/share/site_header.html`: changed the right-side navbar container from `<div class="navbar-nav">` to `<ul class="navbar-nav">` so the previously stray `<li>` items (search-bar toggle and the user-menu / sign-in link) are contained in a proper list.
3. **Elements must only use permitted ARIA attributes** (Home) — `templates/share/site_header.html`: removed the hardcoded `aria-current="page"` from the "Search the Biorepository" nav link (it was statically applied regardless of the active page).
4. **Headings should only increase by one** (Home) — `templates/ctb/landing.html`: changed the three stat-card headings (in both the desktop and mobile blocks) from `<h5>` to `<h2 class="fs-5">` so heading levels increase by one after the page `<h1>`. Visual size is preserved via the `fs-5` Bootstrap class.
5. **Elements must meet minimum color contrast** (Search Samples) — `static/css/style.css`: added `.biosample_tab .text-muted { color: #616970 !important; }` so muted text on the Search Samples page meets WCAG AA 4.5:1 (Bootstrap's default `.text-muted` `#6c757d` sits at the threshold). Scoped to the search page to avoid unrelated changes.

## Where the reviewer can test
- **Login** (`/accounts/login/`): the "Forgot your Password?" link is now underlined.
- **Home / landing page** (`/`): the right-side nav items render inside a `<ul>`; inspect the "Search the Biorepository" nav link to confirm no `aria-current`; the three cards (About / Research and Data Access / Search the Biorepository) now use `<h2>` (with `fs-5` so they look the same), giving a valid h1 -> h2 hierarchy.
- **Search Samples** (Search the Biorepository -> Search Samples): the muted "/count" text and helper text render in a darker gray (`#616970`) that passes AA contrast.

Verified by inspection of the rendered template markup and CSS rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

